### PR TITLE
Use better paths for sockets

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -621,6 +621,7 @@ dependencies = [
  "ecdsa",
  "futures",
  "keyring",
+ "libc",
  "openssl",
  "os_pipe",
  "pgp",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ ring-compat={ version="0.3.1", features=["signature"]}
 openssl="0.10.36"
 keyring="0.10.1"
 pgp="0.7.2"
+libc="0.2"
 
 [[bin]]
 name = "creekey-git-sign"

--- a/src/constants.rs
+++ b/src/constants.rs
@@ -15,3 +15,41 @@ pub fn get_ssh_key_path() -> Result<PathBuf> {
     path.push(SSH_KEY_PATH);
     Ok(path)
 }
+
+pub fn current_uid() -> u32 {
+    unsafe { libc::getuid() }
+}
+
+fn per_user_runtime_dir() -> Option<PathBuf> {
+    if let Some(dir) = dirs::runtime_dir() {
+        return Some(dir);
+    }
+    if cfg!(target_os = "macos") {
+        if let Some(tmpdir) = std::env::var_os("TMPDIR") {
+            return Some(PathBuf::from(tmpdir));
+        }
+    }
+    None
+}
+
+fn runtime_path(base: &str, ext: &str) -> String {
+    match per_user_runtime_dir() {
+        Some(mut path) => {
+            path.push(format!("{}.{}", base, ext));
+            path.to_string_lossy().into_owned()
+        }
+        None => format!("/tmp/{}-{}.{}", base, current_uid(), ext),
+    }
+}
+
+pub fn agent_socket_path() -> String {
+    runtime_path("ck-ssh-agent", "sock")
+}
+
+pub fn agent_pid_path() -> String {
+    runtime_path("ck-agent", "pid")
+}
+
+pub fn logger_socket_path(random: &str) -> String {
+    runtime_path(&format!("ck-logger-{}", random), "sock")
+}

--- a/src/setup_ssh.rs
+++ b/src/setup_ssh.rs
@@ -1,17 +1,99 @@
+use crate::constants::agent_socket_path;
 use crate::output::Log;
 use anyhow::{Context, Result};
 use colored::Color;
-use std::fs::OpenOptions;
-use std::io::{stdin, Read, Write};
+use std::fs;
+use std::io::stdin;
+use std::path::PathBuf;
 
-const SSH_CONF: &str = "# creekey config v1\nHost *\n\tIdentityAgent /tmp/ck-ssh-agent.sock\n\tProxyCommand creekey proxy %h %p\n# /creekey config";
+const CURRENT_VERSION: &str = "v2";
+const START_PREFIX: &str = "# creekey config ";
+const END_MARKER: &str = "# /creekey config";
+
+#[derive(Debug)]
+pub enum SshConfigState {
+    NoCreekeyBlock,
+    AlreadyCurrent,
+    Upgraded { from: String },
+}
+
+fn ssh_config_path() -> Result<PathBuf> {
+    let mut path = dirs::home_dir().context("could not find home dir")?;
+    path.push(".ssh");
+    path.push("config");
+    Ok(path)
+}
+
+fn render_conf() -> String {
+    format!(
+        "{}{}\nHost *\n\tIdentityAgent {}\n\tProxyCommand creekey proxy %h %p\n{}",
+        START_PREFIX,
+        CURRENT_VERSION,
+        agent_socket_path(),
+        END_MARKER,
+    )
+}
+
+fn strip_existing_block(contents: &str) -> Option<(String, String)> {
+    let start = contents.find(START_PREFIX)?;
+    let after_start = &contents[start + START_PREFIX.len()..];
+    let version_end = after_start.find('\n').unwrap_or(after_start.len());
+    let version = after_start[..version_end].trim().to_string();
+
+    let end_rel = contents[start..].find(END_MARKER)?;
+    let mut end = start + end_rel + END_MARKER.len();
+    if contents.as_bytes().get(end) == Some(&b'\n') {
+        end += 1;
+    }
+
+    let mut stripped = String::with_capacity(contents.len());
+    stripped.push_str(&contents[..start]);
+    stripped.push_str(&contents[end..]);
+    Some((stripped, version))
+}
+
+fn append_conf(mut base: String, conf: &str) -> String {
+    if !base.is_empty() && !base.ends_with('\n') {
+        base.push('\n');
+    }
+    base.push_str(conf);
+    if !base.ends_with('\n') {
+        base.push('\n');
+    }
+    base
+}
+
+/// Rewrites `~/.ssh/config` if it contains an outdated creekey block.
+/// Does *not* add a new block when none exists — that's `setup_ssh`'s job.
+pub fn auto_migrate_ssh_config() -> Result<SshConfigState> {
+    let path = ssh_config_path()?;
+
+    let existing = match fs::read_to_string(&path) {
+        Ok(s) => s,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => {
+            return Ok(SshConfigState::NoCreekeyBlock);
+        }
+        Err(e) => return Err(e.into()),
+    };
+
+    let (stripped, version) = match strip_existing_block(&existing) {
+        Some(t) => t,
+        None => return Ok(SshConfigState::NoCreekeyBlock),
+    };
+
+    if version == CURRENT_VERSION {
+        return Ok(SshConfigState::AlreadyCurrent);
+    }
+
+    let new_contents = append_conf(stripped, &render_conf());
+    fs::write(&path, new_contents)?;
+    Ok(SshConfigState::Upgraded { from: version })
+}
 
 pub fn setup_ssh(force: bool) -> Result<()> {
     let log = Log::NONE;
 
-    let mut path = dirs::home_dir().context("could not find home dir")?;
-    path.push(".ssh");
-    path.push("config");
+    let path = ssh_config_path()?;
 
     if !force {
         log.print(
@@ -28,32 +110,47 @@ pub fn setup_ssh(force: bool) -> Result<()> {
         stdin().read_line(&mut input)?;
     }
 
+    let conf = render_conf();
+
     if input.starts_with("y") {
         log.waiting_on("Configuring ssh...")?;
 
-        let mut file = OpenOptions::new()
-            .read(true)
-            .create(true)
-            .append(true)
-            .write(true)
-            .open(path.clone())?;
+        let existing = match fs::read_to_string(&path) {
+            Ok(s) => s,
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => String::new(),
+            Err(e) => return Err(e.into()),
+        };
 
-        let mut str: String = String::new();
-        file.read_to_string(&mut str)?;
+        let (stripped, replaced_version) = match strip_existing_block(&existing) {
+            Some((stripped, version)) => (stripped, Some(version)),
+            None => (existing, None),
+        };
 
-        if str.contains("creekey config v1") {
-            log.success("Config seems to already be there.")?;
-            log.info("If you have problems: manally open the '~/.ssh/config' file and remove the creekey section. then run 'creekey setupssh' again.")?;
+        if replaced_version.as_deref() == Some(CURRENT_VERSION) {
+            log.success("Config is already up to date.")?;
             return Ok(());
         }
-        file.write_all(SSH_CONF.as_bytes())?;
-        log.success("Succesfully Configured SSH!")?;
+
+        let new_contents = append_conf(stripped, &conf);
+        fs::write(&path, new_contents)?;
+
+        match replaced_version {
+            Some(old) => {
+                log.success(&format!(
+                    "Upgraded SSH config from {} to {}.",
+                    old, CURRENT_VERSION
+                ))?;
+            }
+            None => {
+                log.success("Succesfully Configured SSH!")?;
+            }
+        }
         return Ok(());
     }
 
     log.info("You need to tell your ssh system, to use the creekey agent and proxy.")?;
     log.info("Simply copy the following snippet into your '~/.ssh/config' file:")?;
-    eprintln!("{}", SSH_CONF);
+    eprintln!("{}", conf);
 
     Ok(())
 }

--- a/src/ssh_agent.rs
+++ b/src/ssh_agent.rs
@@ -1,4 +1,4 @@
-use crate::constants::get_ssh_key_path;
+use crate::constants::{agent_pid_path, agent_socket_path, get_ssh_key_path};
 
 use anyhow::Context;
 use anyhow::Result;
@@ -13,6 +13,7 @@ use serde::{Deserialize, Serialize};
 use std;
 
 use std::fs;
+use std::path::Path;
 use std::sync::{Arc, Mutex};
 use thiserror::Error;
 use tokio::net::UnixListener;
@@ -24,8 +25,16 @@ use crate::output::{check_color_tty, Log};
 use std::time::{SystemTime, UNIX_EPOCH};
 use tokio::time::Duration;
 
-fn cleanup_socket() {
-    let _ = std::fs::remove_file("/tmp/ck-ssh-agent.sock").unwrap_or(());
+fn try_remove_socket(path: &str) -> std::io::Result<()> {
+    match std::fs::remove_file(path) {
+        Ok(()) => Ok(()),
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+        Err(e) => Err(e),
+    }
+}
+
+fn cleanup_socket_best_effort() {
+    let _ = try_remove_socket(&agent_socket_path());
 }
 
 #[derive(Error, Debug, Clone)]
@@ -87,25 +96,35 @@ pub struct PhoneSignResponse {
 pub async fn start_agent(should_daemonize: bool) -> Result<()> {
     check_color_tty();
 
+    let socket_path = agent_socket_path();
+
     if should_daemonize {
-        let daemonize = Daemonize::new().pid_file("/tmp/ck-agent.pid");
+        let daemonize = Daemonize::new().pid_file(agent_pid_path());
         Log::NONE.waiting_on("Starting deamon...")?;
         daemonize.start()?;
     }
 
     proctitle::set_title("creekey-agent");
     ctrlc::set_handler(move || {
-        cleanup_socket();
+        cleanup_socket_best_effort();
         std::process::exit(0);
     })
     .expect("couldn't set ctrlc handler");
 
-    cleanup_socket();
+    if let Err(e) = try_remove_socket(&socket_path) {
+        if Path::new(&socket_path).exists() {
+            return Err(anyhow::anyhow!(
+                "Could not remove stale agent socket at {}: {}. \
+                 The file is likely owned by another user (e.g. left by a `sudo creekey` run). \
+                 Remove it manually and try again.",
+                socket_path,
+                e,
+            ));
+        }
+    }
 
-    let listener = match UnixListener::bind("/tmp/ck-ssh-agent.sock") {
-        Ok(listener) => listener,
-        Err(e) => panic!("{}", e),
-    };
+    let listener = UnixListener::bind(&socket_path)
+        .with_context(|| format!("Failed to bind agent socket {}", socket_path))?;
 
     println!("Waiting...");
 

--- a/src/ssh_proxy.rs
+++ b/src/ssh_proxy.rs
@@ -1,4 +1,4 @@
-use anyhow::{Context, Result};
+use anyhow::{anyhow, Context, Result};
 use byteorder::{BigEndian, ReadBytesExt, WriteBytesExt};
 use clap::ArgMatches;
 use os_pipe::{dup_stderr, dup_stdin, dup_stdout};
@@ -12,13 +12,17 @@ use std::net::{Shutdown, TcpStream};
 use std::os::unix::net::{UnixListener, UnixStream};
 use std::process::{Command, Stdio};
 
+use crate::constants::{agent_socket_path, logger_socket_path};
 use crate::output::Log;
+use crate::setup_ssh::{auto_migrate_ssh_config, SshConfigState};
 use std::thread;
-use std::time::Duration;
+use std::time::{Duration, Instant};
+
+const DAEMON_START_TIMEOUT: Duration = Duration::from_secs(5);
 
 fn start_logger_proxy() -> Result<String> {
     let random = base64::encode_config(sodiumoxide::randombytes::randombytes(8), base64::URL_SAFE);
-    let name = format!("/tmp/ck-logger-{}.sock", random);
+    let name = logger_socket_path(&random);
 
     let listener = match UnixListener::bind(name.clone()) {
         Ok(listener) => listener,
@@ -51,14 +55,14 @@ fn start_logger_proxy() -> Result<String> {
 }
 
 fn is_agent_running() -> Result<bool> {
-    match UnixStream::connect("/tmp/ck-ssh-agent.sock") {
+    match UnixStream::connect(agent_socket_path()) {
         Ok(_) => Ok(true),
         Err(_) => Ok(false),
     }
 }
 
 fn send_info_packet(host: &str, socket_path: &str, signature: &[u8], key: &[u8]) -> Result<()> {
-    let mut stream = UnixStream::connect("/tmp/ck-ssh-agent.sock")?;
+    let mut stream = UnixStream::connect(agent_socket_path())?;
 
     stream.write_u32::<BigEndian>(
         (1 + 4 + host.len() + 4 + socket_path.len() + 4 + signature.len() + 4 + key.len())
@@ -86,28 +90,74 @@ fn send_info_packet(host: &str, socket_path: &str, signature: &[u8], key: &[u8])
 }
 
 fn check_running_ssh_agent() -> Result<()> {
-    if !is_agent_running()? {
-        Log::NONE.waiting_on("Starting Daemon...")?;
-        let self_arg = &std::env::args().collect::<Vec<String>>()[0];
-
-        let _child = Command::new(self_arg)
-            .arg("agent")
-            .arg("-d")
-            .stdout(Stdio::null())
-            .stdin(Stdio::null())
-            .stderr(Stdio::null())
-            .spawn()
-            .unwrap();
-
-        while !is_agent_running()? {
-            thread::sleep(Duration::from_millis(10))
-        }
+    if is_agent_running()? {
+        return Ok(());
     }
-    Ok(())
+
+    Log::NONE.waiting_on("Starting Daemon...")?;
+    let self_arg = &std::env::args().collect::<Vec<String>>()[0];
+
+    let mut child = Command::new(self_arg)
+        .arg("agent")
+        .arg("-d")
+        .stdout(Stdio::null())
+        .stdin(Stdio::null())
+        .stderr(Stdio::null())
+        .spawn()
+        .context("Failed to spawn creekey agent")?;
+
+    let started_at = Instant::now();
+    loop {
+        if is_agent_running()? {
+            return Ok(());
+        }
+
+        if let Some(status) = child.try_wait()? {
+            // The `daemonize` crate forks the actual daemon and exits the
+            // intermediate process with success — that's normal. Only a
+            // non-success exit means the daemon failed to start.
+            if !status.success() {
+                return Err(anyhow!(
+                    "creekey agent failed to start (exit {}). \
+                     If a stale socket from another user exists at {}, remove it manually and try again.",
+                    status,
+                    agent_socket_path(),
+                ));
+            }
+        }
+
+        if started_at.elapsed() >= DAEMON_START_TIMEOUT {
+            return Err(anyhow!(
+                "Timed out after {:?} waiting for the creekey agent to bind {}. \
+                 Check whether a stale socket from another user is blocking it.",
+                DAEMON_START_TIMEOUT,
+                agent_socket_path(),
+            ));
+        }
+
+        thread::sleep(Duration::from_millis(10));
+    }
 }
 
 pub fn start_ssh_proxy(matches: &ArgMatches) -> Result<()> {
     let socket_path = start_logger_proxy()?;
+
+    match auto_migrate_ssh_config() {
+        Ok(SshConfigState::Upgraded { from }) => {
+            let _ = Log::NONE.info(&format!(
+                "Migrated ~/.ssh/config from creekey config {} to the current format. \
+                 The next ssh invocation will pick up the new agent socket path.",
+                from
+            ));
+        }
+        Ok(_) => {}
+        Err(e) => {
+            let _ = Log::NONE.info(&format!(
+                "Could not check ~/.ssh/config for outdated creekey config: {}",
+                e
+            ));
+        }
+    }
 
     check_running_ssh_agent()?;
 


### PR DESCRIPTION
Invoking creekey as sudo can leave the agent in a stuck state where it tries to read from a socket owned by root. This causes creekey to hang indefinitely.

This is fixed by using a different socket path per user and also introducing a timeout for the agent to connect.